### PR TITLE
Remove deprecated postgresql image override

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -111,10 +111,6 @@ externalPostgresql:
 # See https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 postgresql:
   enabled: true
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/postgresql
-    tag: 17.6.0-debian-12-r4
   primary:
     resources:
       requests:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -111,6 +111,10 @@ externalPostgresql:
 # See https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 postgresql:
   enabled: true
+  image:
+    registry: docker.io
+    repository: postgres
+    tag: "18"
   primary:
     resources:
       requests:


### PR DESCRIPTION
Fixes security scan errors caused by bitnamilegacy/postgresql image. Uses chart default instead.